### PR TITLE
replaced get_multi to get_list method

### DIFF
--- a/app/api/users/routes.py
+++ b/app/api/users/routes.py
@@ -37,7 +37,7 @@ def read_users(
     """
     skip = pagination["skip"]
     limit = pagination["limit"]
-    users = crud.user.get_multi(db, skip=skip, limit=limit)
+    users = crud.user.get_list(db, skip=skip, limit=limit)
     total = crud.user.get_total_count(db)
 
     response.headers["X-Total-Count"] = str(total)


### PR DESCRIPTION
File "/app/app/api/users/routes.py", line 40, in read_users
web-1            |     users = crud.user.get_multi(db, skip=skip, limit=limit)
web-1            |             ^^^^^^^^^^^^^^^^^^^
web-1            | AttributeError: 'CRUDUser' object has no attribute 'get_multi'

to fix error replaced the get_multi method to get_list method from crud.base