### PR TITLE
Fixed bug with bcrypt and passlib. Changed message broker to Redis.

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -74,9 +74,7 @@ class Settings(BaseSettings):
     S3_BUCKET = os.getenv('S3_BUCKET')
     S3_BASE_URL = "https://{S3_BUCKET}.s3.{AWS_REGION}.amazonaws.com/"
 
-    RABBITMQ_USER = os.getenv('RABBITMQ_USER')
-    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD')
-    BROKER_URL = f'pyamqp://{RABBITMQ_USER}:{RABBITMQ_PASSWORD}@rabbitmq//'
+    BROKER_URL = 'redis://redis:6379/0'
 
     class Config:
         case_sensitive = True

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -49,7 +49,7 @@ class InvitationService:
 
     def invite_user(self, user: User) -> Invitation:
         activation_url = create_activation_url(user_id=user.id, user_email=user.email)
-        send_invitation_email.delay(email_to=user.email, url=activation_url)
+        send_invitation_email.apply_async(kwargs={'email_to': user.email, 'url': activation_url}, countdown=1)
         invitation = self.create_invitation(user)
         return invitation
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - .:/app
     depends_on:
       - db
-      - rabbitmq
+      - redis
 
   db:
     image: postgres:14.1-alpine
@@ -23,23 +23,22 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      
-  rabbitmq:
-    image: "rabbitmq:3.10-management"
-    environment:
-      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
-      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+
+  redis:
+    image: redis:alpine
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
       
-  celery_worker:
+  celery:
     build: .
     command: celery -A app.services.celery worker --loglevel=info
     depends_on:
       - web
-      - rabbitmq
+      - redis
 
 volumes:
   postgres_data:
     driver: local
+  redis-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,11 @@ alembic = "^1.11.1"
 python-multipart = "^0.0.6"
 uvicorn = "^0.23.2"
 pytest = "^7.4.0"
-bcrypt = "^4.0.1"
+bcrypt = "4.0.1"
 fastapi-filter = "0.6.1"
 boto3 = "1.33.11"
-celery = "^5.3.6"
+celery = {version = "^5.3.6", extras = ["redis"]}
+redis = "^5.0.2"
 
 
 


### PR DESCRIPTION
** Bug with passlib and bcrypt has been fixed:

> Traceback (most recent call last):
>   File "/usr/local/lib/python3.11/site-packages/passlib/handlers/bcrypt.py", line 620, in _load_backend_mixin
>     version = _bcrypt.__about__.__version__
>               ^^^^^^^^^^^^^^^^^
> AttributeError: module 'bcrypt' has no attribute '__about__'

The reason for the bug is that the passlib has not been updated for a long time, but the bcrypt is still changing.

** The method of sending an invitation email using Celery has been changed. apply_async is more stable method.

** Changed message broker from RabbitMQ to Redis.